### PR TITLE
Add shared send socket and pcap functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ go:
   - 1.8
   - tip
 
+before_install:
+  - sudo apt-get install -q libpcap-dev
+
 install: make install_ci
 
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ go:
   - tip
 
 before_install:
-  - sudo apt-get install -q libpcap-dev
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -q libpcap-dev ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libpcap ; fi
 
 install: make install_ci
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ DC-to-External-Services issues by generating minimal traffic:
 (accidental or not)
 - Whether network-level SLAs are met
 
+## Requirements
+
+ * libpcap
 
 ## Usage
 

--- a/defines/defines.go
+++ b/defines/defines.go
@@ -37,6 +37,7 @@ const (
 	ChannelOutBufferSize            = 800
 	DNSRefreshInterval              = 12 * time.Hour
 	HTTPResponseHeaderTimeout       = 10 * time.Second
+	IPTTL                           = 64
 	LogFileSizeMaxMB                = 15
 	LogFileSizeKeepKB               = 250
 	OrchestratorRESTConf            = "conf"
@@ -44,6 +45,7 @@ const (
 	MaxNumSrcTCPPorts               = 512
 	MinBatchInterval                = 10 * time.Second
 	NumQOSDCSPValues                = 11
+	PcapMaxSnapLen                  = 128
 	PortHTTP                        = 80
 	PortHTTPS                       = 443
 	TimestampPayloadLengthBytes     = 15

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6c48a928ebeb369b08050b29a1169d8350cdd2a5a6337cae4d4dbc29bfeea009
-updated: 2017-05-05T01:01:42.338569518Z
+hash: d34034d4aba4b8adfa5b71ccf367ab53194d50c1a851f746352b4d0affd7646f
+updated: 2017-06-15T11:00:12.683129577-04:00
 imports:
 - name: github.com/DataDog/datadog-go
   version: 909c02b65dd8a52e8fa6072db9752a112227cf21
@@ -7,6 +7,11 @@ imports:
   - statsd
 - name: github.com/fatih/color
   version: dea9d3a26a087187530244679c1cfb3a42937794
+- name: github.com/google/gopacket
+  version: e20408befa7dcef61c3c35f53df06d3f8a194e60
+  subpackages:
+  - layers
+  - pcap
 - name: github.com/jawher/mow.cli
   version: 772320464101e904cd51198160eb4d489be9cc49
 - name: github.com/mattn/go-colorable
@@ -22,7 +27,7 @@ imports:
   subpackages:
   - _cgo
 - name: github.com/uber-go/zap
-  version: 6a4e056f2cc954cfec3581729e758909604b3f76
+  version: 9cabc84638b70e564c3dab2766efcb1ded2aac9f
   subpackages:
   - zapcore
 - name: github.com/uber/uber-licence

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,6 +5,7 @@ import:
   - statsd
 - package: github.com/fatih/color
 - package: github.com/google/gopacket
+  version: ^1
   subpackages:
   - pcap
   - layers

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,6 +4,10 @@ import:
   subpackages:
   - statsd
 - package: github.com/fatih/color
+- package: github.com/google/gopacket
+  subpackages:
+  - pcap
+  - layers
 - package: github.com/jawher/mow.cli
 - package: github.com/miekg/dns
 - package: github.com/pkg/errors

--- a/internal/ip/ip.go
+++ b/internal/ip/ip.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ip
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+
+	"github.com/uber/arachne/defines"
+	"github.com/uber/arachne/internal/log"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	"go.uber.org/zap"
+)
+
+// Conn represents the underyling functionality to send and recv Arachne echo requests
+type Conn struct {
+	SrcAddr net.IP
+	AF      int
+	sendFD  int
+	recvSrc gopacket.PacketDataSource
+}
+
+// Close is used to close a Conn's send file descriptor and Recv packet source
+func (c *Conn) Close() error {
+	return syscall.Close(c.sendFD)
+}
+
+// NextPacket gets the next available packet from the PacketDataSource
+func (c *Conn) NextPacket() (gopacket.Packet, error) {
+	data, _, err := c.recvSrc.ReadPacketData()
+	if err != nil {
+		return nil, err
+	}
+	return gopacket.NewPacket(data, layers.LinkTypeEthernet, gopacket.DecodeOptions{Lazy: true}), nil
+}
+
+// Sendto operates on a Conn file descriptor and mirrors the Sendto syscall
+func (c *Conn) Sendto(b []byte, to net.IP) error {
+	sockAddr, err := ipToSockaddr(c.AF, to, 0)
+	if err != nil {
+		return err
+	}
+
+	return syscall.Sendto(c.sendFD, b, 0, sockAddr)
+}
+
+// getSendSocket will create a raw socket for sending data
+func getSendSocket(af int) (int, error) {
+	fd, err := syscall.Socket(af, syscall.SOCK_RAW, syscall.IPPROTO_RAW)
+	if err != nil {
+		return 0, err
+	}
+
+	err = syscall.SetsockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_HDRINCL, 1)
+	if err != nil {
+		return 0, err
+	}
+
+	return fd, nil
+}
+
+func getRecvSource(listenPort uint32, intf string) (gopacket.PacketDataSource, error) {
+	// Filter for tcp packets coming into ListenPort, http, or HTTPS and contain a SYN flag
+	filter := fmt.Sprintf("(dst port %d or dst port %d or dst port %d) and (tcp[13] & 2 != 0)",
+		listenPort,
+		defines.PortHTTP,
+		defines.PortHTTPS)
+
+	handle, err := pcap.OpenLive(intf, defines.PcapMaxSnapLen, true, pcap.BlockForever)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = handle.SetBPFFilter(filter); err != nil {
+		return nil, err
+	}
+
+	handle.SetDirection(pcap.DirectionIn)
+
+	return handle, nil
+}
+
+// NewConn returns a raw socket connection to send and receive packets
+func NewConn(af int, listenPort uint32, intf string, srcAddr net.IP, logger *log.Logger) *Conn {
+	fds, err := getSendSocket(af)
+	if err != nil {
+		logger.Fatal("Error creating send socket",
+			zap.Int("Address Family", af),
+			zap.Error(err))
+	}
+
+	rs, err := getRecvSource(listenPort, intf)
+	if err != nil {
+		logger.Fatal("Error creating recv source",
+			zap.Uint32("listenPort", listenPort),
+			zap.String("interface", intf),
+			zap.Error(err))
+	}
+
+	return &Conn{
+		SrcAddr: srcAddr,
+		AF:      af,
+		sendFD:  fds,
+		recvSrc: rs,
+	}
+}
+
+func getIPHeaderLayerV6(tos uint8, tcpLen int, srcIP, dstIP net.IP) *layers.IPv6 {
+	return &layers.IPv6{
+		Version:      6,
+		TrafficClass: tos,
+		Length:       uint16(tcpLen),
+		NextHeader:   layers.IPProtocolTCP,
+		SrcIP:        srcIP,
+		DstIP:        dstIP,
+	}
+}
+
+// GetIPHeaderLayer returns the appriately versioned gopacket IP layer
+func GetIPHeaderLayer(af int, tos uint8, tcpLen int, srcIP, dstIP net.IP) (gopacket.NetworkLayer, error) {
+	switch af {
+	case defines.AfInet:
+		return getIPHeaderLayerV4(tos, tcpLen, srcIP, dstIP), nil
+	case defines.AfInet6:
+		return getIPHeaderLayerV6(tos, tcpLen, srcIP, dstIP), nil
+	}
+
+	return nil, fmt.Errorf("invalid address family")
+}
+
+func ipToSockaddr(family int, ip net.IP, port int) (syscall.Sockaddr, error) {
+	switch family {
+	case syscall.AF_INET:
+		if len(ip) == 0 {
+			ip = net.IPv4zero
+		}
+		ip4 := ip.To4()
+		if ip4 == nil {
+			return nil, &net.AddrError{Err: "non-IPv4 address", Addr: ip.String()}
+		}
+		sa := &syscall.SockaddrInet4{Port: port}
+		copy(sa.Addr[:], ip4)
+		return sa, nil
+	case syscall.AF_INET6:
+		if len(ip) == 0 || ip.Equal(net.IPv4zero) {
+			ip = net.IPv6zero
+		}
+		ip6 := ip.To16()
+		if ip6 == nil {
+			return nil, &net.AddrError{Err: "non-IPv6 address", Addr: ip.String()}
+		}
+		sa := &syscall.SockaddrInet6{Port: port}
+		copy(sa.Addr[:], ip6)
+		return sa, nil
+	}
+	return nil, &net.AddrError{Err: "invalid address family", Addr: ip.String()}
+}

--- a/internal/ip/ip.go
+++ b/internal/ip/ip.go
@@ -135,7 +135,7 @@ func NewConn(af int, listenPort uint32, intf string, srcAddr net.IP, logger *log
 	fdSend, err := getSendSocket(af)
 	if err != nil {
 		logger.Fatal("Error creating send socket",
-			zap.Int("Address Family", af),
+			zap.Int("address_family", af),
 			zap.Error(err))
 	}
 
@@ -157,7 +157,7 @@ func NewConn(af int, listenPort uint32, intf string, srcAddr net.IP, logger *log
 
 func getIPHeaderLayerV6(tos uint8, tcpLen uint16, srcIP net.IP, dstIP net.IP) *layers.IPv6 {
 	return &layers.IPv6{
-		Version:      6,
+		Version:      6, // IP Version 6
 		TrafficClass: tos,
 		Length:       tcpLen,
 		NextHeader:   layers.IPProtocolTCP,

--- a/internal/ip/ip.go
+++ b/internal/ip/ip.go
@@ -25,7 +25,8 @@ import (
 	"net"
 	"syscall"
 
-	"github.com/uber/arachne/defines"
+	"github.com/pkg/errors"
+	d "github.com/uber/arachne/defines"
 	"github.com/uber/arachne/internal/log"
 
 	"github.com/google/gopacket"
@@ -34,7 +35,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// Conn represents the underyling functionality to send and recv Arachne echo requests
+// Conn represents the underyling functionality to send and recv Arachne echo requests.
 type Conn struct {
 	SrcAddr net.IP
 	AF      int
@@ -42,112 +43,18 @@ type Conn struct {
 	recvSrc gopacket.PacketDataSource
 }
 
-// Close is used to close a Conn's send file descriptor and Recv packet source
+// Close is used to close a Conn's send file descriptor and Recv packet source.
 func (c *Conn) Close() error {
 	return syscall.Close(c.sendFD)
 }
 
-// NextPacket gets the next available packet from the PacketDataSource
+// NextPacket gets the next available packet from the PacketDataSource.
 func (c *Conn) NextPacket() (gopacket.Packet, error) {
 	data, _, err := c.recvSrc.ReadPacketData()
 	if err != nil {
 		return nil, err
 	}
 	return gopacket.NewPacket(data, layers.LinkTypeEthernet, gopacket.DecodeOptions{Lazy: true}), nil
-}
-
-// Sendto operates on a Conn file descriptor and mirrors the Sendto syscall
-func (c *Conn) Sendto(b []byte, to net.IP) error {
-	sockAddr, err := ipToSockaddr(c.AF, to, 0)
-	if err != nil {
-		return err
-	}
-
-	return syscall.Sendto(c.sendFD, b, 0, sockAddr)
-}
-
-// getSendSocket will create a raw socket for sending data
-func getSendSocket(af int) (int, error) {
-	fd, err := syscall.Socket(af, syscall.SOCK_RAW, syscall.IPPROTO_RAW)
-	if err != nil {
-		return 0, err
-	}
-
-	err = syscall.SetsockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_HDRINCL, 1)
-	if err != nil {
-		return 0, err
-	}
-
-	return fd, nil
-}
-
-func getRecvSource(listenPort uint32, intf string) (gopacket.PacketDataSource, error) {
-	// Filter for tcp packets coming into ListenPort, http, or HTTPS and contain a SYN flag
-	filter := fmt.Sprintf("(dst port %d or dst port %d or dst port %d) and (tcp[13] & 2 != 0)",
-		listenPort,
-		defines.PortHTTP,
-		defines.PortHTTPS)
-
-	handle, err := pcap.OpenLive(intf, defines.PcapMaxSnapLen, true, pcap.BlockForever)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = handle.SetBPFFilter(filter); err != nil {
-		return nil, err
-	}
-
-	handle.SetDirection(pcap.DirectionIn)
-
-	return handle, nil
-}
-
-// NewConn returns a raw socket connection to send and receive packets
-func NewConn(af int, listenPort uint32, intf string, srcAddr net.IP, logger *log.Logger) *Conn {
-	fds, err := getSendSocket(af)
-	if err != nil {
-		logger.Fatal("Error creating send socket",
-			zap.Int("Address Family", af),
-			zap.Error(err))
-	}
-
-	rs, err := getRecvSource(listenPort, intf)
-	if err != nil {
-		logger.Fatal("Error creating recv source",
-			zap.Uint32("listenPort", listenPort),
-			zap.String("interface", intf),
-			zap.Error(err))
-	}
-
-	return &Conn{
-		SrcAddr: srcAddr,
-		AF:      af,
-		sendFD:  fds,
-		recvSrc: rs,
-	}
-}
-
-func getIPHeaderLayerV6(tos uint8, tcpLen int, srcIP, dstIP net.IP) *layers.IPv6 {
-	return &layers.IPv6{
-		Version:      6,
-		TrafficClass: tos,
-		Length:       uint16(tcpLen),
-		NextHeader:   layers.IPProtocolTCP,
-		SrcIP:        srcIP,
-		DstIP:        dstIP,
-	}
-}
-
-// GetIPHeaderLayer returns the appriately versioned gopacket IP layer
-func GetIPHeaderLayer(af int, tos uint8, tcpLen int, srcIP, dstIP net.IP) (gopacket.NetworkLayer, error) {
-	switch af {
-	case defines.AfInet:
-		return getIPHeaderLayerV4(tos, tcpLen, srcIP, dstIP), nil
-	case defines.AfInet6:
-		return getIPHeaderLayerV6(tos, tcpLen, srcIP, dstIP), nil
-	}
-
-	return nil, fmt.Errorf("invalid address family")
 }
 
 func ipToSockaddr(family int, ip net.IP, port int) (syscall.Sockaddr, error) {
@@ -176,4 +83,97 @@ func ipToSockaddr(family int, ip net.IP, port int) (syscall.Sockaddr, error) {
 		return sa, nil
 	}
 	return nil, &net.AddrError{Err: "invalid address family", Addr: ip.String()}
+}
+
+// Sendto operates on a Conn file descriptor and mirrors the Sendto syscall.
+func (c *Conn) Sendto(b []byte, to net.IP) error {
+	sockAddr, err := ipToSockaddr(c.AF, to, 0)
+	if err != nil {
+		return err
+	}
+
+	return syscall.Sendto(c.sendFD, b, 0, sockAddr)
+}
+
+// getSendSocket will create a raw socket for sending data.
+func getSendSocket(af int) (int, error) {
+	fd, err := syscall.Socket(af, syscall.SOCK_RAW, syscall.IPPROTO_RAW)
+	if err != nil {
+		return 0, err
+	}
+
+	if err = syscall.SetsockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_HDRINCL, 1); err != nil {
+		return 0, err
+	}
+
+	return fd, nil
+}
+
+func getRecvSource(listenPort uint32, intf string) (gopacket.PacketDataSource, error) {
+	// Filter for tcp packets coming into ListenPort, http, or HTTPS and contain a SYN flag
+	filter := fmt.Sprintf("(dst port %d or src port %d or src port %d) and (tcp[13] & 2 != 0)",
+		listenPort,
+		d.PortHTTP,
+		d.PortHTTPS)
+
+	handle, err := pcap.OpenLive(intf, d.PcapMaxSnapLen, false, pcap.BlockForever)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = handle.SetBPFFilter(filter); err != nil {
+		return nil, err
+	}
+
+	handle.SetDirection(pcap.DirectionIn)
+
+	return handle, nil
+}
+
+// NewConn returns a raw socket connection to send and receive packets.
+func NewConn(af int, listenPort uint32, intf string, srcAddr net.IP, logger *log.Logger) *Conn {
+	fdSend, err := getSendSocket(af)
+	if err != nil {
+		logger.Fatal("Error creating send socket",
+			zap.Int("Address Family", af),
+			zap.Error(err))
+	}
+
+	rs, err := getRecvSource(listenPort, intf)
+	if err != nil {
+		logger.Fatal("Error creating recv source",
+			zap.Uint32("listenPort", listenPort),
+			zap.String("interface", intf),
+			zap.Error(err))
+	}
+
+	return &Conn{
+		SrcAddr: srcAddr,
+		AF:      af,
+		sendFD:  fdSend,
+		recvSrc: rs,
+	}
+}
+
+func getIPHeaderLayerV6(tos uint8, tcpLen int, srcIP net.IP, dstIP net.IP) *layers.IPv6 {
+	return &layers.IPv6{
+		Version:      6,
+		TrafficClass: tos,
+		Length:       uint16(tcpLen),
+		NextHeader:   layers.IPProtocolTCP,
+		SrcIP:        srcIP,
+		DstIP:        dstIP,
+	}
+}
+
+// GetIPHeaderLayer returns the appriately versioned gopacket IP layer
+func GetIPHeaderLayer(af int, tos uint8, tcpLen int, srcIP net.IP, dstIP net.IP) (gopacket.NetworkLayer, error) {
+	switch af {
+	case d.AfInet:
+		return getIPHeaderLayerV4(tos, tcpLen, srcIP, dstIP), nil
+	case d.AfInet6:
+		return getIPHeaderLayerV6(tos, tcpLen, srcIP, dstIP), nil
+	}
+
+	return nil, errors.Errorf("invalid address family")
 }

--- a/internal/ip/ip_darwin.go
+++ b/internal/ip/ip_darwin.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ip
+
+import (
+	"net"
+
+	"github.com/uber/arachne/defines"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// GetIPLayerOptions is used to get the gopacket serialization options
+func GetIPLayerOptions() gopacket.SerializeOptions {
+	return gopacket.SerializeOptions{
+		ComputeChecksums: true,
+		// Gopacket does not yet support making lengths host-byte order for BSD-based Kernels
+		FixLengths: false,
+	}
+}
+
+func getIPHeaderLayerV4(tos uint8, tcpLen int, srcIP, dstIP net.IP) *layers.IPv4 {
+	header := &layers.IPv4{
+		Version:    4,
+		TOS:        tos,
+		IHL:        5,
+		Length:     uint16(tcpLen) + 20,
+		FragOffset: 0,
+		Flags:      0,
+		TTL:        defines.IPTTL,
+		Protocol:   layers.IPProtocolTCP,
+		Checksum:   0,
+		SrcIP:      srcIP,
+		DstIP:      dstIP,
+	}
+
+	// Manually convert Length and FragOffset to host-byte order for Darwin
+	header.Length = (header.Length << 8) | (header.Length >> 8)
+	nf := layers.IPv4Flag(header.FragOffset & 0xE0)
+	header.FragOffset = (header.FragOffset & 0x1F << 8) | (header.FragOffset>>8 | uint16(header.Flags))
+	header.Flags = nf
+
+	return header
+}

--- a/internal/ip/ip_darwin.go
+++ b/internal/ip/ip_darwin.go
@@ -38,17 +38,17 @@ func GetIPLayerOptions() gopacket.SerializeOptions {
 	}
 }
 
-func getIPHeaderLayerV4(tos uint8, tcpLen int, srcIP net.IP, dstIP net.IP) *layers.IPv4 {
+func getIPHeaderLayerV4(tos uint8, tcpLen uint16, srcIP net.IP, dstIP net.IP) *layers.IPv4 {
 	header := &layers.IPv4{
-		Version:    4,
+		Version:    4, // IP Version 4
 		TOS:        tos,
-		IHL:        5,
-		Length:     uint16(tcpLen) + 20,
-		FragOffset: 0,
-		Flags:      0,
+		IHL:        5,           // IHL: 20 bytes
+		Length:     tcpLen + 20, // Total IP packet length
+		FragOffset: 0,           // No fragmentation
+		Flags:      0,           // Flags for fragmentation
 		TTL:        defines.IPTTL,
 		Protocol:   layers.IPProtocolTCP,
-		Checksum:   0,
+		Checksum:   0, // Computed at serialization time
 		SrcIP:      srcIP,
 		DstIP:      dstIP,
 	}

--- a/internal/ip/ip_darwin.go
+++ b/internal/ip/ip_darwin.go
@@ -29,7 +29,7 @@ import (
 	"github.com/google/gopacket/layers"
 )
 
-// GetIPLayerOptions is used to get the gopacket serialization options
+// GetIPLayerOptions is used to get the gopacket serialization options.
 func GetIPLayerOptions() gopacket.SerializeOptions {
 	return gopacket.SerializeOptions{
 		ComputeChecksums: true,
@@ -38,7 +38,7 @@ func GetIPLayerOptions() gopacket.SerializeOptions {
 	}
 }
 
-func getIPHeaderLayerV4(tos uint8, tcpLen int, srcIP, dstIP net.IP) *layers.IPv4 {
+func getIPHeaderLayerV4(tos uint8, tcpLen int, srcIP net.IP, dstIP net.IP) *layers.IPv4 {
 	header := &layers.IPv4{
 		Version:    4,
 		TOS:        tos,

--- a/internal/ip/ip_linux.go
+++ b/internal/ip/ip_linux.go
@@ -38,9 +38,9 @@ func GetIPLayerOptions() gopacket.SerializeOptions {
 	}
 }
 
-func getIPHeaderLayerV4(tos uint8, tcpLen int, srcIP net.IP, dstIP net.IP) *layers.IPv4 {
+func getIPHeaderLayerV4(tos uint8, tcpLen uint16, srcIP net.IP, dstIP net.IP) *layers.IPv4 {
 	return &layers.IPv4{
-		Version:  4,
+		Version:  4, // IP Version 4
 		TOS:      tos,
 		Protocol: layers.IPProtocolTCP,
 		TTL:      defines.IPTTL,

--- a/internal/ip/ip_linux.go
+++ b/internal/ip/ip_linux.go
@@ -29,8 +29,8 @@ import (
 	"github.com/google/gopacket/layers"
 )
 
-// GetIPLayerOptions returns the gopacket options for serialization specific to Linux
-// In linux, gopacket correctly computes the ip Header lengths and checksum
+// GetIPLayerOptions returns the gopacket options for serialization specific to Linux.
+// In linux, gopacket correctly computes the ip Header lengths and checksum.
 func GetIPLayerOptions() gopacket.SerializeOptions {
 	return gopacket.SerializeOptions{
 		ComputeChecksums: true,
@@ -38,7 +38,7 @@ func GetIPLayerOptions() gopacket.SerializeOptions {
 	}
 }
 
-func getIPHeaderLayerV4(tos uint8, tcpLen int, srcIP, dstIP net.IP) *layers.IPv4 {
+func getIPHeaderLayerV4(tos uint8, tcpLen int, srcIP net.IP, dstIP net.IP) *layers.IPv4 {
 	return &layers.IPv4{
 		Version:  4,
 		TOS:      tos,

--- a/internal/ip/ip_linux.go
+++ b/internal/ip/ip_linux.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ip
+
+import (
+	"net"
+
+	"github.com/uber/arachne/defines"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// GetIPLayerOptions returns the gopacket options for serialization specific to Linux
+// In linux, gopacket correctly computes the ip Header lengths and checksum
+func GetIPLayerOptions() gopacket.SerializeOptions {
+	return gopacket.SerializeOptions{
+		ComputeChecksums: true,
+		FixLengths:       true,
+	}
+}
+
+func getIPHeaderLayerV4(tos uint8, tcpLen int, srcIP, dstIP net.IP) *layers.IPv4 {
+	return &layers.IPv4{
+		Version:  4,
+		TOS:      tos,
+		Protocol: layers.IPProtocolTCP,
+		TTL:      defines.IPTTL,
+		SrcIP:    srcIP,
+		DstIP:    dstIP,
+	}
+}


### PR DESCRIPTION
This commit adds the underlying code that will be used in the future to improve the overall sending and receiving of echo Messages. These coming future changes will address the following:

1. Using a single, shared, file descriptor (raw socket) for the sending of Echo requests. Currently, Arachne creates a new raw socket for each outbound packet, which is not ideal. 

2. Using pcap for receiving incoming echo requests from other agents. This will allow the agents to benefit from BPF filters and thus not have to process _all_ the incoming TCP packets to the system that Arachne is running on (which currently causes a significant overhead).